### PR TITLE
Deploy using travis-ci and git-ftp

### DIFF
--- a/.git-ftp-ignore
+++ b/.git-ftp-ignore
@@ -1,0 +1,2 @@
+README.md
+.git-ftp-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# travis-ci to deploy website to FTP server using git-ftp
+dist: trusty
+language: generic
+addons:
+  apt:
+    packages:
+    - git-ftp
+after_success:
+  - travis_retry ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Site Web de la société technique Élikos.
+
+## Deploy
+
+See [`git-ftp`](https://github.com/git-ftp/git-ftp).
+
+First, [install `git-ftp`](https://github.com/git-ftp/git-ftp/blob/master/INSTALL.md).
+
+Set the environment variables for `FTP_URL`, `FTP_USER`, and `FTP_PASSWORD`, then
+
+```
+./deploy.sh
+```

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Deploy to FTP server using git-ftp
+
+# Set preferences here
+# Some environment variables have to be set separately (FTP_URL, FTP_USER, and FTP_PASSWORD)
+FTP_REMOTE_ROOT=nova_html/new/
+FTP_SYNC_ROOT=src/
+
+# Set git-ftp parameters
+# Note: the remote-root option is not used, because travis-ci has access
+#       to an old version of git-ftp which does not support it; it is
+#       therefore appended to the URL
+git config git-ftp.url ftp://${FTP_URL}/${FTP_REMOTE_ROOT}
+git config git-ftp.user $FTP_USER
+git config git-ftp.password $FTP_PASSWORD
+git config git-ftp.syncroot $FTP_SYNC_ROOT
+
+# Deploy
+# Note: this assumes that `git ftp init` was previously called, i.e. that
+#       a .git-ftp.log file exists at the right location on the server
+git ftp push -v


### PR DESCRIPTION
This is just to test automatic deployment to FTP server using travis-ci. Right now, Travis is set to build pull requests, so it will actually "build" and deploy.

However, once we get this working, we'll remove the option to build pull requests, thus we'll only deploy after pushes to master.